### PR TITLE
Make email matching less restrictive

### DIFF
--- a/lib/turnip/helpers/email.rb
+++ b/lib/turnip/helpers/email.rb
@@ -20,7 +20,7 @@ module Turnip
       private
       def email_jobs
         ::ActiveJob::Base.queue_adapter.enqueued_jobs.select do |job|
-          job[:job] == ActionMailer::DeliveryJob
+          job[:job].to_s['ActionMailer']
         end
       end
     end

--- a/lib/turnip/steps/version.rb
+++ b/lib/turnip/steps/version.rb
@@ -1,5 +1,5 @@
 module Turnip
   module Steps
-    VERSION = '0.1.8'
+    VERSION = '0.1.9'
   end
 end


### PR DESCRIPTION
I have a project where rails uses `ActionMailer::Parameterized::DeliveryJob`. The email matcher should probably only need to search on jobs that have the name `ActionMailer` in it as anything in the job queue from `ActionMailer` is probably involving emails.